### PR TITLE
fix: update build scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,7 @@ jobs:
     - name: Pack
       id: artifacts
       if: ${{ fromJson(needs.M.outputs.RELEASE) }}
-      run: ${{ env.FLOW_COMMAND }} -s Pack,Artifacts
+      run: ${{ env.FLOW_COMMAND }} -s Pack,Store
 
 #     ##     ## ########  ##        #######     ###    ########
 #     ##     ## ##     ## ##       ##     ##   ## ##   ##     ##

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@
   - [x] `report`
   - [x] `build`
   - [x] `files`
-  - [x] `line_coverage`
+  - [x] `line_coverage` _(0.18.0)_
   - [ ] `function_coverage`
   - [ ] `branch_coverage`
 - [x] Wrap I/O in Z streams _(0.2.0-alpha)_
@@ -57,13 +57,13 @@
   - [x] `cov log` _(0.14.0)_
   - [x] `cov tag` / `branch` / `checkout` _(0.15.0)_
   - [x] `cov reset` _(0.16.0)_
-  - [ ] `cov show` _(0.17.0)_
+  - [x] `cov show` _(0.17.0)_
     - [x] Report / component / directory view
     - [x] File view
   - [x] `cov report` reprise
     - [x] `cov report --prop`
     - [x] show propset in `report`
-    - [x] show propset in non-`log` `show`s
+    - [x] show propset in non-`log` `show`s _(0.18.0)_
     - [ ] show propset in `log`
     - [ ] `$COV_FILTER_PATH`
   - [ ] `cov cherry-pick` (?)

--- a/tools/flow/lib/matrix.py
+++ b/tools/flow/lib/matrix.py
@@ -361,7 +361,7 @@ class steps:
         )
 
     @staticmethod
-    @step_call("Artifacts")
+    @step_call("Store")
     def store(config: dict):
         preset = config["preset"]
         packages_dir = f"build/{preset}/packages"

--- a/tools/flow/run.py
+++ b/tools/flow/run.py
@@ -15,7 +15,7 @@ import lib.runner as runner
 DEF_STEPS = {
     "config": ["Conan", "CMake"],
     "build": ["Build"],
-    "verify": ["Build", "Test", "Report", "Pack", "Artifacts", "BinInst", "DevInst"],
+    "verify": ["Build", "Test", "Report", "Pack", "Store", "BinInst", "DevInst"],
 }
 cmd = os.path.splitext(os.path.basename(sys.argv[0]))[0]
 


### PR DESCRIPTION
BREAKING CHANGE: Data structures between 0.17.3 and 0.18.0 change to the point of being unusable. Store your local aliases from `.git/.covdata/setup`, remove the `.git/.covdata` and re-init the cov repo with newest version of tools (via `cov init`).